### PR TITLE
Batch support

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -16,6 +16,21 @@ declare namespace PinejsClientCoreFactory {
 		[index: string]: T
 	}
 
+	interface MimemessageFactory {
+		factory(cs: BatchFactory): CompiledBatch
+	}
+
+	interface BatchFactory {
+		body: string | Array<BatchFactory>
+		contentTransferEncoding: string
+		contentType: string
+	}
+
+	interface CompiledBatch {
+		header(name:string, value?:string): string | void
+		toString(options:{noHeaders: boolean}): string
+	}
+
 	type FilterOperationValue = Filter
 	type FilterFunctionValue = Filter
 
@@ -125,6 +140,12 @@ declare namespace PinejsClientCoreFactory {
 		[index: string]: any
 	}
 
+	interface RequestBase {
+		method: string
+		url: string
+		body?: AnyObject
+	}
+
 	export type Params = {
 		apiPrefix?: string
 		method?: ODataMethod
@@ -168,19 +189,23 @@ declare namespace PinejsClientCoreFactory {
 
 		delete(params: Params): PromiseObj
 
+		batch(data: Array<Params>): Promise<{}>
+
 		compile(params: Params): string
+
+		compileBatch(data: Array<Params>): CompiledBatch
 
 		request(params: Params, overrides: { method?: ODataMethod }): PromiseObj
 
 		abstract _request(
 			params: {
-				method: string,
-				url: string,
-				body?: AnyObject,
+				method: string
+				url: string
+				body?: AnyObject
 			} & AnyObject): PromiseObj
 	}
 }
 
-declare function PinejsClientCoreFactory(utils: PinejsClientCoreFactory.Util, Promise: PinejsClientCoreFactory.PromiseRejector): typeof PinejsClientCoreFactory.PinejsClientCore
+declare function PinejsClientCoreFactory(utils: PinejsClientCoreFactory.Util, Promise: PinejsClientCoreFactory.PromiseRejector, mimemessage: PinejsClientCoreFactory.MimemessageFactory): typeof PinejsClientCoreFactory.PinejsClientCore
 
 export = PinejsClientCoreFactory

--- a/core.d.ts
+++ b/core.d.ts
@@ -17,18 +17,18 @@ declare namespace PinejsClientCoreFactory {
 	}
 
 	interface MimemessageFactory {
-		factory(cs: BatchFactory): CompiledBatch
+		factory(cs: BatchParams): CompiledBatch
 	}
 
-	interface BatchFactory {
-		body: string | Array<BatchFactory>
+	interface BatchParams {
+		body: string | Array<BatchParams>
 		contentTransferEncoding: string
 		contentType: string
 	}
 
 	interface CompiledBatch {
-		header(name:string, value?:string): string | void
-		toString(options:{noHeaders: boolean}): string
+		header(name: string, value?: string): string | void
+		toString(options: {noHeaders: boolean}): string
 	}
 
 	type FilterOperationValue = Filter
@@ -140,11 +140,6 @@ declare namespace PinejsClientCoreFactory {
 		[index: string]: any
 	}
 
-	interface RequestBase {
-		method: string
-		url: string
-		body?: AnyObject
-	}
 
 	export type Params = {
 		apiPrefix?: string
@@ -153,6 +148,7 @@ declare namespace PinejsClientCoreFactory {
 		id?: ResourceId
 		url?: string
 		body?: AnyObject
+		headers?: AnyObject
 		passthrough?: AnyObject
 		passthroughByMethod?: {
 			GET: AnyObject
@@ -189,11 +185,11 @@ declare namespace PinejsClientCoreFactory {
 
 		delete(params: Params): PromiseObj
 
-		batch(data: Array<Params>): Promise<{}>
+		batch(data: Array<Params>, overrides?: AnyObject): Promise<{}>
 
 		compile(params: Params): string
 
-		compileBatch(data: Array<Params>): CompiledBatch
+		compileBatch(data: Array<Params>, overrides?: AnyObject): CompiledBatch
 
 		request(params: Params, overrides: { method?: ODataMethod }): PromiseObj
 
@@ -206,6 +202,10 @@ declare namespace PinejsClientCoreFactory {
 	}
 }
 
-declare function PinejsClientCoreFactory(utils: PinejsClientCoreFactory.Util, Promise: PinejsClientCoreFactory.PromiseRejector, mimemessage: PinejsClientCoreFactory.MimemessageFactory): typeof PinejsClientCoreFactory.PinejsClientCore
+declare function PinejsClientCoreFactory(
+	utils: PinejsClientCoreFactory.Util,
+	Promise: PinejsClientCoreFactory.PromiseRejector,
+	mimemessage: PinejsClientCoreFactory.MimemessageFactory
+): typeof PinejsClientCoreFactory.PinejsClientCore
 
 export = PinejsClientCoreFactory

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bluebird": "^3.0.6",
     "bluebird-lru-cache": "^1.0.0",
     "lodash": "^4.0.0",
+    "mimemessage": "^1.0.4",
     "request": "^2.82.0",
     "typed-error": "^0.1.0"
   },

--- a/request.coffee
+++ b/request.coffee
@@ -1,6 +1,7 @@
 _ = require 'lodash'
 request = require 'request'
 Promise = require 'bluebird'
+mimemessage = require 'mimemessage'
 PinejsClientCore = require './core'
 BluebirdLRU = require 'bluebird-lru-cache'
 TypedError = require 'typed-error'
@@ -12,7 +13,7 @@ class StatusError extends TypedError
 		super(@message)
 
 validParams = ['cache']
-module.exports = class PinejsClientRequest extends PinejsClientCore(_, Promise)
+module.exports = class PinejsClientRequest extends PinejsClientCore(_, Promise, mimemessage)
 	constructor: (params, backendParams) ->
 		super(params)
 		@backendParams = {}
@@ -29,8 +30,8 @@ module.exports = class PinejsClientRequest extends PinejsClientCore(_, Promise)
 		params.timeout ?= 30000
 		# We default to enforcing valid ssl certificates, after all there's a reason we're using them!
 		params.strictSSL ?= true
-		# The request is always a json request.
-		params.json = true
+		# The request must not be a json if it is a batch. In every other case it must be.
+		params.json ?= true
 
 		if @cache? and params.method is 'GET'
 			# If the cache is enabled and we are doing a GET then try to use a cached

--- a/test/batch.coffee
+++ b/test/batch.coffee
@@ -1,0 +1,99 @@
+{ testBatch } = require './test'
+ppJson = (json) -> JSON.stringify(json, null, 2)
+testBatchReq = (input, output) ->
+	it "should compile #{ppJson(input)} to #{ppJson(output)}", ->
+		testBatch output, input
+
+dev1 =
+	name: 'First'
+	devtype: 'b1'
+
+dev2 =
+	name: 'Second'
+	devtype: 'b2'
+
+dev3 =
+	name: 'Third'
+	devtype: 'cs1'
+
+dev4 =
+	name: 'Fourth'
+	devtype: 'cs2'
+
+req1 = {
+	url: '/testpine/device'
+	method: 'POST'
+	body: dev1
+}
+req2 = {
+	url: '/testpine/device'
+	method: 'POST'
+	body: dev2
+}
+req3 = {
+	url: '/testpine/device'
+	method: 'GET'
+}
+
+cs1 = {
+	url: '$2'
+	method: 'PUT'
+	'Content-ID': 1
+	body: dev4
+}
+
+cs2 = {
+	url: '/testpine/device'
+	method: 'POST'
+	'Content-ID': 2
+	body: dev3
+}
+
+
+req1Compiled = {
+	'body': 'POST /testpine/device HTTP/1.1\r\n{\"name\":\"First\",\"devtype\":\"b1\"}',
+	'Content-Transfer-Encoding': 'binary',
+	'Content-Type': 'application/json'
+}
+
+req2Compiled = {
+	'body': 'POST /testpine/device HTTP/1.1\r\n{\"name\":\"Second\",\"devtype\":\"b2\"}',
+	'Content-Transfer-Encoding': 'binary',
+	'Content-Type': 'application/json'
+}
+
+req3Compiled = {
+	'Content-Transfer-Encoding': 'binary',
+	'Content-Type': 'application/http',
+	'body': 'GET /testpine/device HTTP/1.1\r\n'
+}
+
+cs1Compiled = {
+	'Content-Type': 'application/json',
+	'Content-ID': 1,
+	'Content-Transfer-Encoding': 'binary',
+	'body': 'PUT $2 HTTP/1.1\r\n{\"name\":\"Fourth\",\"devtype\":\"cs2\"}'
+}
+
+cs2Compiled = {
+	'Content-Type': 'application/json',
+	'Content-ID': 2,
+	'Content-Transfer-Encoding': 'binary',
+	'body': 'POST /testpine/device HTTP/1.1\r\n{\"name\":\"Third\",\"devtype\":\"cs1\"}'
+
+}
+
+testBatchReq(
+	[ req1, req2 ]
+	[ req1Compiled, req2Compiled ]
+)
+
+testBatchReq(
+	[ req1, [ cs1, cs2 ], req3 ]
+	[ req1Compiled, [ cs1Compiled, cs2Compiled ], req3Compiled ]
+)
+
+testBatchReq(
+	[ [ cs2, cs1 ], req3, req2, req1 ]
+	[ [ cs2Compiled, cs1Compiled ], req3Compiled, req2Compiled, req1Compiled ]
+)

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -22,6 +22,8 @@ exports.testBatch = (expected, params) ->
 			_.forEach entity.body, (CSentity, CSindex) ->
 				checkEntity(expected[index][CSindex], CSentity)
 
+exports.compile = (params) -> return core.compile(params)
+
 checkEntity = (expectation, entity) ->
 	for key, value of expectation
 		if key is 'body' then expect(entity.body).to.equal(value)

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -2,12 +2,27 @@ expect = require('chai').expect
 
 _ = require 'lodash'
 Promise = require 'bluebird'
+mimemessage = require 'mimemessage'
+
 PinejsClientCore = require '../core'
 
-PinejsClientCore = PinejsClientCore(_, Promise)
+PinejsClientCore = PinejsClientCore(_, Promise, mimemessage)
 core = new PinejsClientCore()
 exports.test = (expected, params) ->
 	if _.isError(expected)
 		expect(-> core.compile(params)).to.throw(expected.constructor, expected.message)
 	else
 		expect(core.compile(params)).to.equal expected
+
+exports.testBatch = (expected, params) ->
+	_.forEach core.compileBatch(params).body, (entity, index) ->
+		if _.isString(entity.body)
+			checkEntity(expected[index], entity)
+		else
+			_.forEach entity.body, (CSentity, CSindex) ->
+				checkEntity(expected[index][CSindex], CSentity)
+
+checkEntity = (expectation, entity) ->
+	for key, value of expectation
+		if key is 'body' then expect(entity.body).to.equal(value)
+		else expect(entity.header(key)).to.equal(value)


### PR DESCRIPTION
The external API now supports a batch method that will perform a batch
request. Internally we rely on mimemessage to compile an array of
requests to a valid multipart/mixed request body.

I made some changes from the first implementation to allow it to work any http backend (including in-browser)