### PR TITLE
Drop unnecessary async from request()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1123,7 +1123,7 @@ export abstract class PinejsClientCore<PinejsClient> {
 		}
 	}
 
-	public async request(params: Params, overrides?: undefined): Promise<{}> {
+	public request(params: Params, overrides?: undefined): Promise<{}> {
 		if (overrides !== undefined) {
 			throw new Error(
 				'request(params, overrides)` is unsupported, please use `request({ ...params, ...overrides })` instead.',


### PR DESCRIPTION
This allows consumers like pinejs-client-supertest
to have all the methods returning different Promise
types based solely on the implementation of the
request() method.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>