### PR TITLE
Improve $orderby typing to allow `[{a: 'desc'}, {b: 'asc'}]`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1421,7 +1421,7 @@ export type Expand = string | ResourceExpand | Array<string | ResourceExpand>;
 
 export type OrderBy =
 	| string
-	| string[]
+	| OrderBy[]
 	| {
 			[index: string]: 'asc' | 'desc';
 	  };


### PR DESCRIPTION
Change-type: patch