### PR TITLE
Avoid modifying the resulting promise when retries are not used

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1414,9 +1414,9 @@ export abstract class PinejsClientCore<PinejsClient> {
 			method,
 		};
 
-		return this.callWithRetry(async () => {
-			return await this._request(opts);
-		}, retry);
+		// Do not await this._request result, so that we can preserve
+		// the potentially enhanced promise-like result.
+		return this.callWithRetry(() => this._request(opts), retry);
 	}
 
 	public abstract _request(


### PR DESCRIPTION
This was by far the simplest way to get pinejs-client-supertest to work again :(

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>