### PR TITLE
Fix $count typings to only allow $filter under it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1584,8 +1584,9 @@ export interface ODataOptionsWithoutCount {
 		| Expand
 		| OrderBy;
 }
+export type ODataCountOptions = Pick<ODataOptionsWithoutCount, '$filter'>;
 export interface ODataOptions extends ODataOptionsWithoutCount {
-	$count?: ODataOptionsWithoutCount;
+	$count?: ODataCountOptions;
 }
 export type OptionsObject = ODataOptions;
 


### PR DESCRIPTION
Afaict this is not allowed and odata-to-abstractsql ignores the extras props:
```
expandPath        = *( ( complexProperty / complexColProperty / optionallyQualifiedComplexTypeName / complexAnnotationInQuery ) "/" )
                    ( STAR [ ref / OPEN levels CLOSE ]
                    / streamProperty 
                    / ( navigationProperty / entityAnnotationInQuery ) [ "/" optionallyQualifiedEntityTypeName ] 
                      [ ref   [ OPEN expandRefOption   *( SEMI expandRefOption   ) CLOSE ] // <========
                      / count [ OPEN expandCountOption *( SEMI expandCountOption ) CLOSE ]
                      /         OPEN expandOption      *( SEMI expandOption      ) CLOSE 
                      ]
                    )

collectionPathExpr = count [ OPEN expandCountOption *( SEMI expandCountOption ) CLOSE ] // // <========
                   / filterExpr [ collectionPathExpr ]
                   / "/" anyExpr
                   / "/" allExpr
                   / "/" boundFunctionExpr
                   / "/" annotationExpr

expandCountOption = filter
                  / search
```


Change-type: patch
See: https://docs.oasis-open.org/odata/odata/v4.01/os/abnf/odata-abnf-construction-rules.txt
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>