### PR TITLE
Add support for `$filter: { $op: [{ $count: {} }, number] }` notation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ const deprecated = (() => {
 			"'`$expand: { 'a/$count': {...} }` is deprecated, please use `$expand: { a: { $count: {...} } }` instead.",
 		countWithNestedOperationInFilter:
 			"'`$filter: { a: { $count: { $op: number } } }` is deprecated, please use `$filter: { $eq: [ { a: { $count: {} } }, number ] }` instead.",
+		countInOrderBy:
+			"'`$orderby: 'a/$count'` is deprecated, please use `$orderby: { a: { $count: {...} } }` instead.",
 		non$filterOptionIn$expand$count:
 			'using OData options other than $filter in a `$expand: { a: { $count: {...} } }` is deprecated, please remove them.',
 	};
@@ -657,6 +659,9 @@ const buildFilter = (
 
 const buildOrderBy = (orderby: OrderBy): string => {
 	if (isString(orderby)) {
+		if (/\/\$count\b/.test(orderby)) {
+			deprecated.countInOrderBy();
+		}
 		return orderby;
 	} else if (Array.isArray(orderby)) {
 		if (orderby.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ const deprecated = (() => {
 			"'`resource: 'a/$count'` is deprecated, please use `options: { $count: { ... } }` instead.",
 		countInExpand:
 			"'`$expand: { 'a/$count': {...} }` is deprecated, please use `$expand: { a: { $count: {...} } }` instead.",
+		countWithNestedOperationInFilter:
+			"'`$filter: { a: { $count: { $op: number } } }` is deprecated, please use `$filter: { $eq: [ { a: { $count: {} } }, number ] }` instead.",
 		non$filterOptionIn$expand$count:
 			'using OData options other than $filter in a `$expand: { a: { $count: {...} } }` is deprecated, please remove them.',
 	};
@@ -502,6 +504,7 @@ const handleFilterOperator = (
 				keys = parentKey.concat(keys);
 			}
 			// Handles the `$filter: a: $count: value` case.
+			deprecated.countWithNestedOperationInFilter();
 			return buildFilter(filter as Filter, keys);
 		}
 		// break

--- a/test/filter.coffee
+++ b/test/filter.coffee
@@ -660,6 +660,22 @@ testFilter(
 	'a/$count eq 1'
 )
 
+testFilter(
+	$lt: [
+		a: $count: {}
+		1
+	]
+	'a/$count lt 1'
+)
+
+testFilter(
+	$lt: [
+		a: $count: $filter: b: 'c'
+		1
+	]
+	"a/$count($filter=b eq 'c') lt 1"
+)
+
 # Test functions
 testFunction('contains')
 testFunction('endswith')
@@ -727,6 +743,28 @@ testLambda = (operator) ->
 			createFilter
 				$alias: 'b'
 		new Error("Lambda expression (#{operator}) has no expr defined.")
+	)
+
+	testFilter(
+		a:
+			createFilter
+				$alias: 'al'
+				$expr: $eq: [
+					al: b: $count: {}
+					1
+				]
+		"a/#{operator.slice(1)}(al:al/b/$count eq 1)"
+	)
+
+	testFilter(
+		a:
+			createFilter
+				$alias: 'al'
+				$expr: $eq: [
+					al: b: $count: $filter: c: 'd'
+					1
+				]
+		"a/#{operator.slice(1)}(al:al/b/$count($filter=c eq 'd') eq 1)"
 	)
 
 # Test $any


### PR DESCRIPTION
On top of https://github.com/balena-io-modules/pinejs-client-js/pull/127

Add support for `$filter: { $op: [{ $count: {} }, number] }` notation

Change-type: minor
See: https://balena.zulipchat.com/#narrow/stream/345882-_help/topic/.E2.9C.94.20pinejs.20filter.20query.20count
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>