### PR TITLE
tests: Support `.only` & `.skip` in the higher level test functions

### DIFF
--- a/test/filter.coffee
+++ b/test/filter.coffee
@@ -1,7 +1,7 @@
-{ test } = require './test'
+{ buildMochaHelper, test } = require './test'
 _ = require 'lodash'
 
-testFilter = (input, output) ->
+testFilter = buildMochaHelper it, (it, input, output) ->
 	resource = 'test'
 	if not _.isError(output)
 		countOutput = resource + '/$count?$filter=' + output

--- a/test/options.coffee
+++ b/test/options.coffee
@@ -1,7 +1,7 @@
-{ test } = require './test'
+{ buildMochaHelper, test } = require './test'
 _ = require 'lodash'
 
-testId = (input, output) ->
+testId = buildMochaHelper it, (it, input, output) ->
 	resource = 'test'
 	if not _.isError(output)
 		output = "#{resource}(#{output})"
@@ -11,7 +11,7 @@ testId = (input, output) ->
 			id: input
 		}
 
-testOption = (option, input, output) ->
+testOption = buildMochaHelper it, (it, option, input, output) ->
 	resource = 'test'
 	if not _.isError(output)
 		output = "#{resource}?#{option}=#{output}"

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -9,3 +9,9 @@ exports.test = (expected, params) ->
 		expect(-> core.compile(params)).to.throw(expected.constructor, expected.message)
 	else
 		expect(core.compile(params)).to.equal expected
+
+exports.buildMochaHelper = (mochaFn, runExpectation) ->
+	ret = runExpectation.bind(null, mochaFn)
+	ret.skip = runExpectation.bind(null, mochaFn.skip)
+	ret.only = runExpectation.bind(null, mochaFn.only)
+	return ret


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>