### PR TITLE
Add support for using model specific typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@balena/abstract-sql-to-typescript": "^3.1.1",
     "@balena/es-version": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This requires passing the model typings when creating the pinejs-client
instance and will mean that any usage after that will be type checked
to limit to resources/properties that exist on the model. This covers
almost all usage but there are some cases we cannot cover as we would
need typescript support for partial inference of generics, eg for
lambdas, or to make major changes to the querying interface.
This work should also be fully backwards compatible such that if you do
not provide model typings then all typings should continue to work as
previously

Change-type: minor