### PR TITLE
Correctly type the `POST` result as being fully deferred

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1545,7 +1545,7 @@ export abstract class PinejsClientCore<
 
 	public post<TResource extends StringKeyOf<Model>>(
 		params: { resource: TResource } & Params<Model[TResource]>,
-	): Promise<Model[TResource]['Read']>;
+	): Promise<PickDeferred<Model[TResource]['Read']>>;
 	/**
 	 * @deprecated POSTing via `url` is deprecated
 	 */


### PR DESCRIPTION
Previously it did not state so the expanded versions were available in the typings even though the result would never actually include them

Change-type: patch