### PR TITLE
Update abstract-sql-to-typescript to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@balena/abstract-sql-to-typescript": "^3.2.3",
+    "@balena/abstract-sql-to-typescript": "^4.0.0",
     "@balena/es-version": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Change-type: major

---

Note: We might should make this a major because `abstract-sql-to-typescript` now has a peer dependency on `sbvr-types`. For consumers of `abstract-sql-to-typescript`, they would also need to satisfy this nested peer dependency requirement to get proper typings. (Should probably also add `sbvr-types` to peer dependencies here?)