### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting assignment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -302,9 +302,12 @@ class Poll<T extends PromiseResultTypes> {
 	public on(name: 'data', fn: (response: T) => void): PollOnObj;
 	public on(name: 'error', fn: (err: any) => void): PollOnObj;
 	public on(
-		name: keyof Poll<T>['subscribers'],
+		name: 'data' | 'error',
 		fn: (value: any) => void,
 	): PollOnObj {
+		if (name !== 'data' && name !== 'error') {
+			throw new TypeError(`Invalid subscriber type: ${String(name)}`);
+		}
 		const subscribers = this.subscribers[name] as Array<(value: any) => void>;
 		const index = subscribers.push(fn) - 1;
 


### PR DESCRIPTION
Potential fix for [https://github.com/balena-io-modules/pinejs-client-js/security/code-scanning/1](https://github.com/balena-io-modules/pinejs-client-js/security/code-scanning/1)

General fix: validate computed property keys at runtime before indexing/writing, or use a structure immune to prototype keys (e.g., `Map`).  
Best minimal fix here: add a strict runtime allowlist check in `on(...)` so only `'data'` and `'error'` are accepted, then proceed with existing logic unchanged.

In `src/index.ts`, inside `on(...)` (around lines 304–318), insert a guard before `this.subscribers[name]` access:

- If `name !== 'data' && name !== 'error'`, throw a `TypeError`.
- Keep existing subscription/unsubscribe behavior unchanged.

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
